### PR TITLE
Ignore checkpatch.pl ARRAY_SIZE warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ before_script:
   - chmod +x checkpatch.pl
 
 script:
-  - options="--terse --no-tree --max-line-length=80"
+  - options="--terse --no-tree --max-line-length=80 --ignore ARRAY_SIZE"
   - ./checkpatch.pl $options --file src/*
 
 after_script:


### PR DESCRIPTION
According to the documentation, we can ignore various comma-separated message types:

```
--ignore TYPE(,TYPE2...) 
```