### PR TITLE
Low battery alert

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,4 +1,4 @@
-OBJS = detection.o
+OBJS = detection.o common.o battery.o
 
 BINARY = main
 

--- a/src/battery.c
+++ b/src/battery.c
@@ -1,0 +1,19 @@
+#include "battery.h"
+
+/**
+ * @brief ADC1 and ADC2 interruption routine.
+ *
+ * - Manage the ADC2 analog watchdog interruption flag.
+ * - Send a message.
+ * - Toggle a LED.
+ * - Disable analog watchdog interruptions on injected channels.
+ */
+void adc1_2_isr(void)
+{
+	if (adc_get_flag(ADC2, ADC_SR_AWD)) {
+		adc_clear_flag(ADC2, ADC_SR_AWD);
+		printf("WARNING: Battery low!\n");
+		gpio_toggle(GPIOC, GPIO13);
+		adc_disable_analog_watchdog_injected(ADC2);
+	}
+}

--- a/src/battery.h
+++ b/src/battery.h
@@ -1,0 +1,9 @@
+#ifndef __BATTERY_H
+#define __BATTERY_H
+
+#include <libopencm3/stm32/adc.h>
+#include <libopencm3/stm32/gpio.h>
+
+void adc1_2_isr(void);
+
+#endif /* __BATTERY_H */

--- a/src/common.c
+++ b/src/common.c
@@ -1,0 +1,34 @@
+#include "common.h"
+
+/**
+ * @brief Read a status flag.
+ *
+ * @param[in] ADC register address base.
+ *
+ * @param[in] status register flag.
+ *
+ * @returns flag set.
+ *
+ * @see adc_reg_base and ADC_SR values from libopencm3 library.
+ */
+bool adc_get_flag(uint32_t adc_peripheral, uint32_t flag)
+{
+	if ((ADC_SR(adc_peripheral) & flag) != 0)
+		return true;
+
+	return false;
+}
+
+/**
+ * @brief Clear a status flag.
+ *
+ * @param[in] ADC register address base.
+ *
+ * @param[in] Status register flag.
+ *
+ * @see adc_reg_base and ADC_SR values from libopencm3 library.
+ */
+void adc_clear_flag(uint32_t adc_peripheral, uint32_t flag)
+{
+	ADC_SR(adc_peripheral) = ~flag;
+}

--- a/src/common.h
+++ b/src/common.h
@@ -1,0 +1,9 @@
+#ifndef __COMMON_H
+#define __COMMON_H
+
+#include <libopencm3/stm32/adc.h>
+
+bool adc_get_flag(uint32_t adc_peripheral, uint32_t flag);
+void adc_clear_flag(uint32_t adc_peripheral, uint32_t flag);
+
+#endif /* __COMMON_H */

--- a/src/detection.c
+++ b/src/detection.c
@@ -1,8 +1,4 @@
 #include "detection.h"
-#include <libopencm3/stm32/adc.h>
-#include <libopencm3/stm32/gpio.h>
-#include <libopencm3/stm32/timer.h>
-#include <stdio.h>
 
 static void sm_emitter_adc(void);
 

--- a/src/detection.h
+++ b/src/detection.h
@@ -1,6 +1,11 @@
 #ifndef __DETECTION_H
 #define __DETECTION_H
 
+#include <libopencm3/stm32/adc.h>
+#include <libopencm3/stm32/gpio.h>
+#include <libopencm3/stm32/timer.h>
+#include <stdio.h>
+
 void tim1_up_isr(void);
 
 /* State machine status */


### PR DESCRIPTION
Review after #81 
- Analog watchdog with a low threshold of 1.8V configured on ADC2.
- Interruption that toggles a LED, sends a message and disables ADC2 watchdog interruption generation.
- New files:  common (watchdog flag management functions), battery (interruption actions)
- Add the includes for detection.c better on detection.h file (as for battery.h and battery.c)


