### PR TITLE
Use both stderr and stdout descriptors in _write

### DIFF
--- a/src/logging.c
+++ b/src/logging.c
@@ -2,12 +2,14 @@
 
 /**
  * @brief Make `printf` send characters through the USART.
+ *
+ * Both standard output and standard error are redirected through the USART.
  */
 int _write(int file, char *ptr, int len)
 {
 	int i;
 
-	if (file == 1) {
+	if (file == STDOUT_FILENO || file == STDERR_FILENO) {
 		for (i = 0; i < len; i++)
 			usart_send_blocking(USART3, ptr[i]);
 		return i;

--- a/src/logging.h
+++ b/src/logging.h
@@ -3,6 +3,7 @@
 
 #include <errno.h>
 #include <stdio.h>
+#include <unistd.h>
 
 #include <libopencm3/stm32/usart.h>
 


### PR DESCRIPTION
Fixes #29.