### PR TITLE
Use LOG_WARNING instead of printf on low battery

### DIFF
--- a/src/battery.c
+++ b/src/battery.c
@@ -12,7 +12,7 @@ void adc1_2_isr(void)
 {
 	if (adc_get_flag(ADC2, ADC_SR_AWD)) {
 		adc_clear_flag(ADC2, ADC_SR_AWD);
-		printf("WARNING: Battery low!\n");
+		LOG_WARNING("Battery low!");
 		gpio_toggle(GPIOC, GPIO13);
 		adc_disable_analog_watchdog_injected(ADC2);
 	}

--- a/src/battery.h
+++ b/src/battery.h
@@ -4,6 +4,8 @@
 #include <libopencm3/stm32/adc.h>
 #include <libopencm3/stm32/gpio.h>
 
+#include "logging.h"
+
 void adc1_2_isr(void);
 
 #endif /* __BATTERY_H */


### PR DESCRIPTION
`printf` was used but not included (i.e.: compilation was failing). Anyway it is better if we only use the `LOG_XXX` functions.