### PR TITLE
Easier local format checking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,7 @@ __pycache__/
 *.out
 *.stylecheck
 *.swp
+const_structs.checkpatch
+checkpatch.pl
 libopencm3.rules.mk
+spelling.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,21 +17,12 @@ install:
   - pip install -r requirements.txt
 
 before_script:
-  - linux="https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git"
-  - wget $linux/plain/scripts/spelling.txt
-  - wget $linux/plain/scripts/checkpatch.pl
-  - wget $linux/plain/scripts/const_structs.checkpatch
-  - chmod +x checkpatch.pl
   - clang-format() { clang-format-4.0 $@; }
   - export -f clang-format
-  - export CHECKPATCH_OPTIONS="--terse --no-tree --max-line-length=80 --ignore ARRAY_SIZE,VOLATILE,LEADING_SPACE"
   - ./scripts/setup_libopencm3.sh
 
 script:
-  - ./scripts/check_format.sh
-  - ./checkpatch.pl $CHECKPATCH_OPTIONS --file src/*
+  - ./scripts/checkformat_clang.sh
+  - ./scripts/checkformat_checkpatch.sh
   - cd src/ && make
   - cd ../ && pytest -sv
-
-after_script:
-  - rm checkpatch.pl

--- a/scripts/checkformat.sh
+++ b/scripts/checkformat.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+$root/checkformat_clang.sh
+$root/checkformat_checkpatch.sh

--- a/scripts/checkformat_checkpatch.sh
+++ b/scripts/checkformat_checkpatch.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+linux="https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git"
+wget --no-clobber --quiet $linux/plain/scripts/spelling.txt
+wget --no-clobber --quiet $linux/plain/scripts/checkpatch.pl
+wget --no-clobber --quiet $linux/plain/scripts/const_structs.checkpatch
+chmod +x checkpatch.pl
+./checkpatch.pl --terse --no-tree --max-line-length=80 --ignore ARRAY_SIZE,VOLATILE,LEADING_SPACE --file src/*.[ch]

--- a/scripts/checkformat_clang.sh
+++ b/scripts/checkformat_clang.sh
@@ -1,12 +1,14 @@
 #!/bin/bash
 output=$(mktemp)
 errors=$(mktemp)
-find src/ -type f -regex ".*\.\(c\|h\)$" | while read fname; do
+find src/ -type f -regex ".*\.\(c\|h\)$" | while read fname
+do
 	clang-format "$fname" > "$output"
 	git diff --color "$fname" "$output" >> "$errors"
 done
 rm -f "$output"
-if [ -s "$errors" ]; then
+if [ -s "$errors" ]
+then
 	echo -e "\033[0;31mFORMATTING ERRORS!\033[0m"
 	cat "$errors"
 	rm -f "$errors"


### PR DESCRIPTION
Now to run the style checks locally simply run:

```
./scripts/checkformat.sh
```